### PR TITLE
Handle empty deck flip edge cases

### DIFF
--- a/WarCardGameEngine.Test/WarCardGameTest.cs
+++ b/WarCardGameEngine.Test/WarCardGameTest.cs
@@ -1,4 +1,5 @@
 using nic_weber.DeckOfCards;
+using System.Reflection;
 
 namespace nic_weber.WarCardGameEngine.Test;
 
@@ -753,5 +754,37 @@ public class UnitTest1
         Assert.Equal(WarCardGame.GameState.DrawByWarRule, game.State);
         Assert.Equal(1, game.PlayerOneDeckSize);
         Assert.Equal(1, game.PlayerTwoDeckSize);
+    }
+
+    [Fact]
+    public void PlayerOneFlipCard_WithEmptyDeck_PlayerTwoWinsGame()
+    {
+        WarCardGame game = new();
+
+        var field = typeof(WarCardGame).GetField("_playerOneDeck", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var deck = (StandardPokerDeck)field.GetValue(game)!;
+
+        while(deck.CardsInDeck > 0)
+            deck.Pop();
+
+        game.PlayerOneFlipCard();
+
+        Assert.Equal(WarCardGame.GameState.PlayerTwoWinsGame, game.State);
+    }
+
+    [Fact]
+    public void PlayerTwoFlipCard_WithEmptyDeck_PlayerOneWinsGame()
+    {
+        WarCardGame game = new();
+
+        var field = typeof(WarCardGame).GetField("_playerTwoDeck", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var deck = (StandardPokerDeck)field.GetValue(game)!;
+
+        while(deck.CardsInDeck > 0)
+            deck.Pop();
+
+        game.PlayerTwoFlipCard();
+
+        Assert.Equal(WarCardGame.GameState.PlayerOneWinsGame, game.State);
     }
 }

--- a/WarCardGameEngine/WarCardGame.cs
+++ b/WarCardGameEngine/WarCardGame.cs
@@ -112,6 +112,11 @@ public class WarCardGame
     /// </summary>
     public void PlayerOneFlipCard()
     {
+        if(_playerOneDeck.CardsInDeck == 0)
+        {
+            State = GameState.PlayerTwoWinsGame;
+            return;
+        }
         switch(State)
         {
             case GameState.WaitingForBothPlayers:
@@ -143,6 +148,11 @@ public class WarCardGame
     /// </summary>
     public void PlayerTwoFlipCard()
     {
+        if(_playerTwoDeck.CardsInDeck == 0)
+        {
+            State = GameState.PlayerOneWinsGame;
+            return;
+        }
         switch(State)
         {
             case GameState.WaitingForBothPlayers:


### PR DESCRIPTION
## Summary
- add deck-empty checks to `PlayerOneFlipCard` and `PlayerTwoFlipCard`
- test flipping with empty decks causes opponent win

## Testing
- `dotnet test -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684346e7eba88327ae41b0d2d3876334